### PR TITLE
Prevent adding a new line at the end of the modified file

### DIFF
--- a/RegexReplace/RegexReplace.ps1
+++ b/RegexReplace/RegexReplace.ps1
@@ -47,7 +47,7 @@ try {
     Write-Host "Replacing $findRegex with $replaceRegex ($ext)"
 
     foreach ($path in $inputPaths) {
-        $setContentParams = @{ Path = $path }
+        $setContentParams = @{ Path = $path; NoNewLine = $true }
         $getContentParams = @{ Path = $path }
 
         Write-Host "...in file $path"


### PR DESCRIPTION
The current version of **RegEx Find & Replace task** always leaves an empty line at the end of the modified file. 

I think that only parts matched by regex should be changed and the rest of the modified file should remain untouched. It's especially crucial in cases of further files comparing.

I've added the `-NoNewLine` flag to the `Set-Content` cmdlet invocation. That omits to add a new line at the end of the modified file.